### PR TITLE
Add aspell installation instructions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -15,7 +15,7 @@ Place this script into the **.git/hooks/** directory in your repository. It must
 
     book]$ ln -s ~/git-spell-check/pre-commit .git/hooks/pre-commit
 
-You will need to install [`aspell`](https://aspell.net/).
+You will need to install [`aspell`](http://aspell.net/).
 
 On Mac:
 

--- a/README.markdown
+++ b/README.markdown
@@ -1,7 +1,7 @@
 Git Spell Check
 ===============
 
-This script is a Git pre-commit hook that spell checks changes in XML files which you are about to commit. This hook is useful in your documentation projects written in DocBook.
+This script is a Git pre-commit hook that spell checks changes in files which you are about to commit. This hook is useful in your documentation projects written in DocBook.
 
 
 Instructions
@@ -14,6 +14,16 @@ To use this script, clone the following repo:
 Place this script into the **.git/hooks/** directory in your repository. It must be called **pre-commit** and be executable. A Git hook only works in a single repository. You need to copy this hook into every repository you wish to use it in manually. Optionally, you can set up a symlink in the **.git/hooks/** directory pointing to the script. That way, each time the script is updated in the GitHub repo, you won't have to replace it in the **.git/hooks/** directory. To create a symlink in your repository, execute:
 
     book]$ ln -s ~/git-spell-check/pre-commit .git/hooks/pre-commit
+
+You will need to install [`aspell`](http://aspell.net/).
+
+On Mac:
+
+	~]$ brew install aspell
+
+On Ubuntu:
+
+	~]$ apt-get install -y aspell
 
 Each time you try to commit something, this script is run to spell check the content you are committing. If misspelled words are found, you can either save them into a custom Aspell dictionary (which means they will be ignored next time the script is run), or ignore them. The following options are available when the script is run:
 
@@ -42,4 +52,3 @@ This program is free software: you can redistribute it and/or modify it under th
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License along with this program. If not, see [http://www.gnu.org/licenses/](http://www.gnu.org/licenses/).
-

--- a/README.markdown
+++ b/README.markdown
@@ -1,7 +1,7 @@
 Git Spell Check
 ===============
 
-This script is a Git pre-commit hook that spell checks changes in files which you are about to commit. This hook is useful in your documentation projects written in DocBook.
+This script is a Git pre-commit hook that spell checks changes in files which you are about to commit.
 
 
 Instructions
@@ -15,7 +15,7 @@ Place this script into the **.git/hooks/** directory in your repository. It must
 
     book]$ ln -s ~/git-spell-check/pre-commit .git/hooks/pre-commit
 
-You will need to install [`aspell`](http://aspell.net/).
+You will need to install [`aspell`](https://aspell.net/).
 
 On Mac:
 


### PR DESCRIPTION
- Add instructions on installing `aspell` for Mac and Ubuntu.
- Removes the note about XML files from the description. CMIIW, but it doesn't seem to limit the file extensions to XML?